### PR TITLE
Fix a bug where gradients change upon item expand

### DIFF
--- a/chrome/content/zotero/components/virtualized-table.jsx
+++ b/chrome/content/zotero/components/virtualized-table.jsx
@@ -837,7 +837,7 @@ class VirtualizedTable extends React.Component {
 		if (this.props.alternatingRowColors) {
 			this._jsWindow.innerElem.style.background = `
 				repeating-linear-gradient(
-				  0deg,
+				  to bottom,
 				  ${this.props.alternatingRowColors[0]},
 				  ${this.props.alternatingRowColors[0]} ${this._rowHeight}px,
 				  ${this.props.alternatingRowColors[1]} ${this._rowHeight}px,

--- a/chrome/content/zotero/containers/itemTree.jsx
+++ b/chrome/content/zotero/containers/itemTree.jsx
@@ -1104,7 +1104,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 					hide: showMessage,
 					key: "virtualized-table",
 					label: Zotero.getString('pane.items.title'),
-					alternatingRowColors: Zotero.isMac ? ['-moz-OddTreeRow', '-moz-EvenTreeRow'] : null,
+					alternatingRowColors: Zotero.isMac ? ['-moz-EvenTreeRow', '-moz-OddTreeRow'] : null,
 
 					showHeader: true,
 					columns: this._getColumns(),


### PR DESCRIPTION
When expanding/collapsing item in the items tree, gradient may "swap", see gif below. This PR fixes this.

**before:**
![virtual-trees-gradient-bug](https://user-images.githubusercontent.com/214628/89593013-5e568a80-d84e-11ea-8d6c-8997ea50fee4.gif)

**after:**
![virtual-trees-gradient-bug-fix](https://user-images.githubusercontent.com/214628/89593023-63b3d500-d84e-11ea-938b-da66ccfe0283.gif)
